### PR TITLE
build.rs: fixes #2 "dynlib" -> "dylib"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn is_static() -> bool {
 fn common() -> Result<(), Error> {
 	if let Ok(path) = env::var("XKBCOMMON_LIB_DIR") {
 		for lib in &["xkbcommon"] {
-			println!("cargo:rustc-link-lib={}={}", if is_static() { "static" } else { "dynlib" }, lib);
+			println!("cargo:rustc-link-lib={}={}", if is_static() { "static" } else { "dylib" }, lib);
 		}
 
 		println!("cargo:rustc-link-search=native={}", path);
@@ -26,7 +26,7 @@ fn x11() -> Result<(), Error> {
 	if env::var("CARGO_FEATURE_X11").is_ok() {
 		if let Ok(path) = env::var("XKBCOMMON_LIB_DIR") {
 			for lib in &["xkbcommon-x11"] {
-				println!("cargo:rustc-link-lib={}={}", if is_static() { "static" } else { "dynlib" }, lib);
+				println!("cargo:rustc-link-lib={}={}", if is_static() { "static" } else { "dylib" }, lib);
 			}
 
 			println!("cargo:rustc-link-search=native={}", path);


### PR DESCRIPTION
Very simple fix, that makes cross-compilation possible.

Now it builds when not using pkg-config and manually specifying library path via env `XKBCOMMON_LIB_DIR`.
