### PR TITLE
Build fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "xkbcommon-sys"
-version = "0.7.4"
+version = "0.7.5"
 
 authors = ["meh. <meh@schizofreni.co>"]
 license = "WTFPL"

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -13,7 +13,7 @@
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 use libc::{c_void, c_int, uint8_t, uint16_t, int32_t};
-use ::{xkb_context, xkb_keymap, xkb_state, xkb_keymap_compile_flags};
+use super::{xkb_context, xkb_keymap, xkb_state, xkb_keymap_compile_flags};
 
 pub const XKB_X11_MIN_MAJOR_XKB_VERSION: c_int = 1;
 pub const XKB_X11_MIN_MINOR_XKB_VERSION: c_int = 0;


### PR DESCRIPTION
Add a fix for compilation with x11.
Bumps the crate version to be in accordance with crates.io.

Resolves: #4 